### PR TITLE
SK-1943 override error messages for collect elements 

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "skyflow-react-js",
   "preferGlobal": true,
   "analyze": false,
-  "version": "2.1.3",
+  "version": "2.1.3-dev.42ee5b6",
   "description": "Skyflow React SDK",
   "homepage": "https://github.com/skyflowapi/skyflow-react",
   "main": "lib/index.js",

--- a/src/elements/CVV/index.tsx
+++ b/src/elements/CVV/index.tsx
@@ -3,7 +3,7 @@
 */
 import React, { FC } from 'react'
 import Skyflow from 'skyflow-js'
-import { CollectElements, ComposableElements, SkyflowCollectElementProps } from '..'
+import { CollectElements, ComposableElements, SkyflowCollectElementProps, SkyflowCollectElementRef } from '..'
 import { ELEMENT_CREATED } from '../../utils/constants'
 import useCollectListeners from '../../hooks/CollectListner'
 import CollectElement from 'skyflow-js/types/core/external/collect/collect-element'
@@ -12,10 +12,14 @@ import { v4 as uuid } from 'uuid';
 import useUpdateElement from '../../hooks/UpdateElement'
 import ComposableElement from 'skyflow-js/types/core/external/collect/compose-collect-element'
 import { createElementValueMatchRule } from '../../utils/helpers'
+import useErrorOverride from '../../hooks/OverrideError'
 
-const CVVElement: FC<SkyflowCollectElementProps> = ({ ...props }) => {
+const CVVElement = React.forwardRef<SkyflowCollectElementRef, SkyflowCollectElementProps>(({ ...props }, ref) => {
   const uniqueDivId = React.useRef(uuid());
   const [element,setElement] = React.useState<CollectElement| ComposableElement | null>(null);
+
+  
+  useErrorOverride(element, ref, props);
 
   React.useEffect(() => {
     try {
@@ -64,6 +68,6 @@ const CVVElement: FC<SkyflowCollectElementProps> = ({ ...props }) => {
     ? (<div id={props.id ? props.id : `CVV-id-${uniqueDivId.current}`}></div>) 
     : (<></>)
   )
-}
+});
 
 export default React.memo(CVVElement);

--- a/src/elements/CardHolderName/index.tsx
+++ b/src/elements/CardHolderName/index.tsx
@@ -4,7 +4,7 @@
 import React, { FC } from 'react'
 import Skyflow from 'skyflow-js'
 import CollectElement from 'skyflow-js/types/core/external/collect/collect-element'
-import { CollectElements, ComposableElements, SkyflowCollectElementProps } from '..'
+import { CollectElements, ComposableElements, SkyflowCollectElementProps, SkyflowCollectElementRef } from '..'
 import useCollectListeners from '../../hooks/CollectListner'
 import { ELEMENT_CREATED } from '../../utils/constants'
 import { SKYFLOW_ERROR_CODE } from '../../utils/errors'
@@ -12,10 +12,13 @@ import { v4 as uuid } from 'uuid';
 import useUpdateElement from '../../hooks/UpdateElement'
 import ComposableElement from 'skyflow-js/types/core/external/collect/compose-collect-element'
 import { createElementValueMatchRule } from '../../utils/helpers'
+import useErrorOverride from '../../hooks/OverrideError'
 
-const CardHolderNameElement: FC<SkyflowCollectElementProps> = ({ ...props }) => {
+const CardHolderNameElement = React.forwardRef<SkyflowCollectElementRef, SkyflowCollectElementProps>(({ ...props }, ref) => {
   const uniqueDivId = React.useRef(uuid());
   const [element,setElement] = React.useState<CollectElement| ComposableElement | null>(null);
+
+  useErrorOverride(element, ref, props);
 
   React.useEffect(() => {
     try {
@@ -63,6 +66,6 @@ const CardHolderNameElement: FC<SkyflowCollectElementProps> = ({ ...props }) => 
       ? (<div id={props.id ? props.id : `CARDHOLDER_NAME-id-${uniqueDivId.current}`}></div>)
       : (<></>)
   )
-}
+})
 
 export default React.memo(CardHolderNameElement)

--- a/src/elements/CardNumber/index.tsx
+++ b/src/elements/CardNumber/index.tsx
@@ -4,7 +4,7 @@
 import React, { FC } from 'react'
 import Skyflow from 'skyflow-js'
 import CollectElement from 'skyflow-js/types/core/external/collect/collect-element'
-import { CollectElements, ComposableElements, SkyflowCollectElementProps } from '..'
+import { CollectElements, ComposableElements, SkyflowCollectElementProps, SkyflowCollectElementRef } from '..'
 import useCollectListeners from '../../hooks/CollectListner'
 import { ELEMENT_CREATED } from '../../utils/constants'
 import { SKYFLOW_ERROR_CODE } from '../../utils/errors'
@@ -12,11 +12,14 @@ import { v4 as uuid } from 'uuid';
 import useUpdateElement from '../../hooks/UpdateElement'
 import ComposableElement from 'skyflow-js/types/core/external/collect/compose-collect-element'
 import { createElementValueMatchRule } from '../../utils/helpers'
+import useErrorOverride from '../../hooks/OverrideError'
 
-const CardNumberElement: FC<SkyflowCollectElementProps> = ({ ...props }) => {
+const CardNumberElement = React.forwardRef<SkyflowCollectElementRef, SkyflowCollectElementProps>(({ ...props }, ref) => {
   const uniqueDivId = React.useRef(uuid());
 
   const [element,setElement] = React.useState<CollectElement| ComposableElement | null>(null);
+
+  useErrorOverride(element, ref, props);
   
   React.useEffect(() => {
     try {
@@ -63,6 +66,6 @@ const CardNumberElement: FC<SkyflowCollectElementProps> = ({ ...props }) => {
     ? (<div id={props.id ? props.id : `CARD_NUMBER-id-${uniqueDivId.current}`}></div>) 
     : (<></>)
   )
-}
+})
 
 export default React.memo(CardNumberElement)

--- a/src/elements/ExpirationDate/index.tsx
+++ b/src/elements/ExpirationDate/index.tsx
@@ -4,7 +4,7 @@
 import React, { FC } from 'react'
 import Skyflow from 'skyflow-js'
 import CollectElement from 'skyflow-js/types/core/external/collect/collect-element'
-import { CollectElements, ComposableElements, SkyflowCollectElementProps } from '..'
+import { CollectElements, ComposableElements, SkyflowCollectElementProps, SkyflowCollectElementRef } from '..'
 import useCollectListeners from '../../hooks/CollectListner'
 import { ELEMENT_CREATED } from '../../utils/constants'
 import { SKYFLOW_ERROR_CODE } from '../../utils/errors'
@@ -12,10 +12,14 @@ import { v4 as uuid } from 'uuid';
 import useUpdateElement from '../../hooks/UpdateElement'
 import ComposableElement from 'skyflow-js/types/core/external/collect/compose-collect-element'
 import { createElementValueMatchRule } from '../../utils/helpers'
+import useErrorOverride from '../../hooks/OverrideError'
 
-const ExpirationDateElement: FC<SkyflowCollectElementProps> = ({ ...props }) => {
+const ExpirationDateElement = React.forwardRef<SkyflowCollectElementRef, SkyflowCollectElementProps>(({ ...props }, ref) => {
   const uniqueDivId = React.useRef(uuid());
   const [element,setElement] = React.useState<CollectElement | ComposableElement | null>(null);
+
+  useErrorOverride(element, ref, props);
+  
   React.useEffect(() => {
     try {
       props.validations = createElementValueMatchRule(props.container, props.validations)
@@ -61,6 +65,6 @@ const ExpirationDateElement: FC<SkyflowCollectElementProps> = ({ ...props }) => 
     ? (<div id={props.id ? props.id : `EXPIRATION_DATE-id-${uniqueDivId.current}`}></div>) 
     : (<></>)
   )
-}
+});
 
 export default React.memo(ExpirationDateElement)

--- a/src/elements/ExpirationMonth/index.tsx
+++ b/src/elements/ExpirationMonth/index.tsx
@@ -4,7 +4,7 @@
 import React, { FC } from 'react'
 import Skyflow from 'skyflow-js'
 import CollectElement from 'skyflow-js/types/core/external/collect/collect-element'
-import { CollectElements, ComposableElements, SkyflowCollectElementProps } from '..'
+import { CollectElements, ComposableElements, SkyflowCollectElementProps, SkyflowCollectElementRef } from '..'
 import useCollectListeners from '../../hooks/CollectListner'
 import { ELEMENT_CREATED } from '../../utils/constants'
 import { SKYFLOW_ERROR_CODE } from '../../utils/errors'
@@ -12,10 +12,14 @@ import { v4 as uuid } from 'uuid';
 import useUpdateElement from '../../hooks/UpdateElement'
 import ComposableElement from 'skyflow-js/types/core/external/collect/compose-collect-element'
 import { createElementValueMatchRule } from '../../utils/helpers'
+import useErrorOverride from '../../hooks/OverrideError'
 
-const ExpirationMonthElement: FC<SkyflowCollectElementProps> = ({ ...props }) => {
+const ExpirationMonthElement = React.forwardRef<SkyflowCollectElementRef, SkyflowCollectElementProps>(({ ...props }, ref) => {
   const uniqueDivId = React.useRef(uuid());
   const [element,setElement] = React.useState<CollectElement | ComposableElement | null>(null);
+
+  useErrorOverride(element, ref, props);
+  
   React.useEffect(() => {
     try {
       props.validations = createElementValueMatchRule(props.container, props.validations)
@@ -62,6 +66,6 @@ const ExpirationMonthElement: FC<SkyflowCollectElementProps> = ({ ...props }) =>
     ? (<div id={props.id ? props.id : `EXPIRATION_MONTH-id-${uniqueDivId.current}`}></div>) 
     : (<></>)
   )
-}
+});
 
 export default React.memo(ExpirationMonthElement)

--- a/src/elements/ExpirationYear/index.tsx
+++ b/src/elements/ExpirationYear/index.tsx
@@ -4,7 +4,7 @@
 import React, { FC } from 'react'
 import Skyflow from 'skyflow-js'
 import CollectElement from 'skyflow-js/types/core/external/collect/collect-element'
-import { CollectElements, ComposableElements, SkyflowCollectElementProps } from '..'
+import { CollectElements, ComposableElements, SkyflowCollectElementProps, SkyflowCollectElementRef } from '..'
 import useCollectListeners from '../../hooks/CollectListner'
 import { ELEMENT_CREATED } from '../../utils/constants'
 import { SKYFLOW_ERROR_CODE } from '../../utils/errors'
@@ -12,10 +12,13 @@ import { v4 as uuid } from 'uuid';
 import useUpdateElement from '../../hooks/UpdateElement'
 import ComposableElement from 'skyflow-js/types/core/external/collect/compose-collect-element'
 import { createElementValueMatchRule } from '../../utils/helpers'
+import useErrorOverride from '../../hooks/OverrideError'
 
-const ExpirationYearElement: FC<SkyflowCollectElementProps> = ({ ...props }) => {
+const ExpirationYearElement = React.forwardRef<SkyflowCollectElementRef, SkyflowCollectElementProps>(({ ...props }, ref) => {
   const uniqueDivId = React.useRef(uuid());
   const [element,setElement] = React.useState<CollectElement| ComposableElement | null>(null);
+
+  useErrorOverride(element, ref, props);
 
   React.useEffect(() => {
     try {
@@ -63,6 +66,6 @@ const ExpirationYearElement: FC<SkyflowCollectElementProps> = ({ ...props }) => 
     : (<></>)
   )
   
-}
+});
 
 export default React.memo(ExpirationYearElement)

--- a/src/elements/FileInputElement/index.tsx
+++ b/src/elements/FileInputElement/index.tsx
@@ -4,7 +4,7 @@
 import React, { FC } from 'react'
 import Skyflow from 'skyflow-js'
 import CollectElement from 'skyflow-js/types/core/external/collect/collect-element'
-import { CollectElements, ComposableElements, SkyflowCollectElementProps } from '..'
+import { CollectElements, ComposableElements, SkyflowCollectElementProps, SkyflowCollectElementRef } from '..'
 import useCollectListeners from '../../hooks/CollectListner'
 import { ELEMENT_CREATED } from '../../utils/constants'
 import { SKYFLOW_ERROR_CODE } from '../../utils/errors'
@@ -12,10 +12,13 @@ import { v4 as uuid } from 'uuid';
 import useUpdateElement from '../../hooks/UpdateElement'
 import ComposableElement from 'skyflow-js/types/core/external/collect/compose-collect-element'
 import { createElementValueMatchRule } from '../../utils/helpers'
+import useErrorOverride from '../../hooks/OverrideError'
 
-const FileInputElement: FC<SkyflowCollectElementProps> = ({ ...props }) => {
+const FileInputElement = React.forwardRef<SkyflowCollectElementRef, SkyflowCollectElementProps>(({ ...props }, ref) => {
   const uniqueDivId = React.useRef(uuid());
   const [element, setElement] = React.useState<CollectElement | ComposableElement | null>(null);
+
+  useErrorOverride(element, ref, props);
 
   React.useEffect(() => {
     try {
@@ -63,6 +66,6 @@ const FileInputElement: FC<SkyflowCollectElementProps> = ({ ...props }) => {
       ? (<div id={props.id ? props.id : `FILE_INPUT-id-${uniqueDivId.current}`}></div>)
       : (<></>)
   )
-}
+});
 
 export default React.memo(FileInputElement)

--- a/src/elements/FileRenderElement/index.tsx
+++ b/src/elements/FileRenderElement/index.tsx
@@ -2,13 +2,16 @@
   Copyright (c) 2022 Skyflow, Inc. 
 */
 import React, { FC } from 'react'
-import { FileRenderElements, SkyflowRenderElementProps } from '..'
+import { FileRenderElements, SkyflowRenderElementProps, SkyflowRenderElementRef } from '..'
 import { v4 as uuid } from 'uuid';
 import useUpdateFileRenderElement from '../../hooks/UpdateFileRenderElement';
+import useErrorOverride from '../../hooks/OverrideError';
 
-const FileRenderElement: FC<SkyflowRenderElementProps> = ({ ...props }) => {
+const FileRenderElement = React.forwardRef<SkyflowRenderElementRef, SkyflowRenderElementProps>(({ ...props }, ref) => {
   const uniqueDivId = React.useRef(uuid());
   const [element, setElement] = React.useState<any>(null);
+
+  useErrorOverride(element, ref, props);
 
   React.useEffect(() => {
     const divElement = document.getElementById(props?.id || `reveal-${uniqueDivId.current}`);
@@ -36,6 +39,6 @@ const FileRenderElement: FC<SkyflowRenderElementProps> = ({ ...props }) => {
 
   useUpdateFileRenderElement(props, element)
   return <div id={props.id ? props.id : `reveal-${uniqueDivId.current}` }></div>
-}
+})
 
 export default React.memo(FileRenderElement);

--- a/src/elements/InputField/index.tsx
+++ b/src/elements/InputField/index.tsx
@@ -4,7 +4,7 @@
 import React, { FC } from 'react'
 import Skyflow from 'skyflow-js'
 import CollectElement from 'skyflow-js/types/core/external/collect/collect-element'
-import { CollectElements, ComposableElements, SkyflowCollectElementProps } from '..'
+import { CollectElements, ComposableElements, SkyflowCollectElementProps, SkyflowCollectElementRef } from '..'
 import useCollectListeners from '../../hooks/CollectListner'
 import { ELEMENT_CREATED } from '../../utils/constants'
 import { SKYFLOW_ERROR_CODE } from '../../utils/errors'
@@ -12,10 +12,14 @@ import { v4 as uuid } from 'uuid';
 import useUpdateElement from '../../hooks/UpdateElement'
 import ComposableElement from 'skyflow-js/types/core/external/collect/compose-collect-element'
 import { createElementValueMatchRule } from '../../utils/helpers'
+import useErrorOverride from '../../hooks/OverrideError'
 
-const InputFieldElement: FC<SkyflowCollectElementProps> = ({ ...props }) => {
+const InputFieldElement = React.forwardRef<SkyflowCollectElementRef, SkyflowCollectElementProps>(({ ...props }, ref) => {
   const uniqueDivId = React.useRef(uuid());
   const [element,setElement] = React.useState<CollectElement| ComposableElement | null>(null);
+
+  useErrorOverride(element, ref, props);
+
   React.useEffect(() => {
     try {
       props.validations = createElementValueMatchRule(props.container, props.validations)
@@ -60,6 +64,6 @@ const InputFieldElement: FC<SkyflowCollectElementProps> = ({ ...props }) => {
     ? (<div id={props.id ? props.id : `INPUT_FIELD-id-${uniqueDivId.current}`}></div>) 
     : (<></>)
   )
-}
+});
 
 export default React.memo(InputFieldElement)

--- a/src/elements/PIN/index.tsx
+++ b/src/elements/PIN/index.tsx
@@ -4,7 +4,7 @@
 import React, { FC } from 'react'
 import Skyflow from 'skyflow-js'
 import CollectElement from 'skyflow-js/types/core/external/collect/collect-element'
-import { CollectElements, ComposableElements, SkyflowCollectElementProps } from '..'
+import { CollectElements, ComposableElements, SkyflowCollectElementProps, SkyflowCollectElementRef } from '..'
 import useCollectListeners from '../../hooks/CollectListner'
 import { ELEMENT_CREATED } from '../../utils/constants'
 import { SKYFLOW_ERROR_CODE } from '../../utils/errors'
@@ -12,10 +12,13 @@ import { v4 as uuid } from 'uuid';
 import useUpdateElement from '../../hooks/UpdateElement'
 import ComposableElement from 'skyflow-js/types/core/external/collect/compose-collect-element'
 import { createElementValueMatchRule } from '../../utils/helpers'
+import useErrorOverride from '../../hooks/OverrideError'
 
-const PinElement: FC<SkyflowCollectElementProps> = ({ ...props }) => {
+const PinElement = React.forwardRef<SkyflowCollectElementRef, SkyflowCollectElementProps>(({ ...props }, ref) => {
   const uniqueDivId = React.useRef(uuid());
   const [element,setElement] = React.useState<CollectElement | ComposableElement | null>(null);
+
+  useErrorOverride(element, ref, props);
   
   React.useEffect(() => {
     try {
@@ -63,6 +66,6 @@ const PinElement: FC<SkyflowCollectElementProps> = ({ ...props }) => {
     ? (<div id={props.id ? props.id : `PIN-id-${uniqueDivId.current}`}></div>) 
     : (<></>)
   )
-}
+});
 
 export default React.memo(PinElement)

--- a/src/elements/RevealElement/index.tsx
+++ b/src/elements/RevealElement/index.tsx
@@ -2,14 +2,17 @@
   Copyright (c) 2022 Skyflow, Inc. 
 */
 import React, { FC } from 'react'
-import { SkyflowRevealElementProps } from '..'
+import { SkyflowCollectElementRef, SkyflowRevealElementProps, SkyflowRevealElementRef } from '..'
 import { v4 as uuid } from 'uuid';
 import Skyflow from 'skyflow-js';
 import useUpdateRevealElement from '../../hooks/UpdateRevealElement';
+import useErrorOverride from '../../hooks/OverrideError';
 
-const RevealElement: FC<SkyflowRevealElementProps> = ({ ...props }) => {
+const RevealElement = React.forwardRef<SkyflowRevealElementRef, SkyflowRevealElementProps>( ({ ...props }, ref) => {
   const uniqueDivId = React.useRef(uuid());
   const [element,setElement] = React.useState<any>(null);
+
+  useErrorOverride(element, ref, props);
 
   React.useEffect(() => {
     const divElement = document.getElementById(props?.id || `reveal-${uniqueDivId.current}`);
@@ -44,6 +47,6 @@ const RevealElement: FC<SkyflowRevealElementProps> = ({ ...props }) => {
 
   useUpdateRevealElement(props, element)
   return <div id={props.id ? props.id : `reveal-${uniqueDivId.current}` }></div>
-}
+})
 
 export default React.memo(RevealElement);

--- a/src/elements/index.ts
+++ b/src/elements/index.ts
@@ -30,7 +30,12 @@ export interface SkyflowCollectElementProps {
   onReady?: (state: unknown) => void
   eventEmitter?:any
   skyflowID?:string
+  ref?: {current: SkyflowCollectElementRef | null};
   // TODO ref 
+}
+
+export interface SkyflowCollectElementRef {
+    setErrorOverride: (errorMessage: string) => void;
 }
 
 export interface SkyflowRevealElementProps {
@@ -42,7 +47,13 @@ export interface SkyflowRevealElementProps {
   classes?: Record<string, unknown>
   options?: IRevealOptions
   redaction?: RedactionType
+  ref?: {current: SkyflowRevealElementRef | null}
 }
+
+export interface SkyflowRevealElementRef {
+  setErrorOverride: (errorMessage: string) => void;
+}
+
 export interface SkyflowRenderElementProps {
   container: RevealContainer
   id: string
@@ -51,6 +62,11 @@ export interface SkyflowRenderElementProps {
   skyflowID:string
   table: string
   column: string
+  ref?: {current: SkyflowRenderElementRef | null};
+}
+
+export interface SkyflowRenderElementRef {
+  setErrorOverride: (errorMessage: string) => void;
 }
 
 export interface ICollectElementOptions {

--- a/src/hooks/OverrideError/index.ts
+++ b/src/hooks/OverrideError/index.ts
@@ -1,0 +1,38 @@
+import {
+  SkyflowCollectElementProps,
+  SkyflowCollectElementRef,
+  SkyflowRenderElementProps,
+  SkyflowRenderElementRef,
+  SkyflowRevealElementProps,
+  SkyflowRevealElementRef,
+} from 'elements';
+import { ForwardedRef, useImperativeHandle } from 'react';
+import CollectElement from 'skyflow-js/types/core/external/collect/collect-element';
+import RevealElement from 'skyflow-js/types/core/external/reveal/reveal-element';
+import Skyflow from 'skyflow-js';
+import ComposableElement from 'skyflow-js/types/core/external/collect/compose-collect-element';
+
+const useErrorOverride = (
+  element: CollectElement | ComposableElement | RevealElement | null,
+  ref: ForwardedRef<SkyflowCollectElementRef | SkyflowRevealElementRef | SkyflowRenderElementRef>,
+  props: SkyflowCollectElementProps | SkyflowRevealElementProps | SkyflowRenderElementProps,
+) => {
+  if (
+    props?.container?.type == Skyflow.ContainerType.COLLECT ||
+    props?.container?.type == Skyflow.ContainerType.REVEAL
+  ) {
+    useImperativeHandle(
+      ref,
+      () => ({
+        setErrorOverride: (errorMessage: string) => {
+          if (element && 'setErrorOverride' in element) {
+            element.setErrorOverride(errorMessage)
+          }
+        },
+      }),
+      [element],
+    )
+  }
+}
+
+export default useErrorOverride;

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import useComposableContainer from './hooks/ComposableContainer'
 import useRenderFile from './hooks/RenderFile'
 import useSkyflow from './hooks/Skyflow'
 import use3DS from './hooks/ThreeDS'
+import { SkyflowCollectElementRef, SkyflowRenderElementRef, SkyflowRevealElementRef } from 'elements'
 
 const LogLevel = Skyflow.LogLevel
 const Env = Skyflow.Env
@@ -62,5 +63,8 @@ export {
   useRenderFile,
   FileRenderElement,
   useSkyflow,
-  use3DS
+  use3DS,
+  SkyflowCollectElementRef,
+  SkyflowRevealElementRef,
+  SkyflowRenderElementRef,
 }

--- a/tests/hooks/useErrorOverride.test.ts
+++ b/tests/hooks/useErrorOverride.test.ts
@@ -1,0 +1,78 @@
+import { renderHook } from '@testing-library/react'
+import { useImperativeHandle } from 'react';
+import Skyflow from 'skyflow-js';
+import CollectElement from 'skyflow-js/types/core/external/collect/collect-element';
+import RevealElement from 'skyflow-js/types/core/external/reveal/reveal-element';
+import ComposableElement from 'skyflow-js/types/core/external/collect/compose-collect-element';
+import useErrorOverride from '../../src/hooks/OverrideError';
+
+describe('test useErrorOverride', () => {
+  it('should set error override when element and container type are valid', () => {
+    const mockSetErrorOverride = jest.fn();
+    const mockElement = {
+      setErrorOverride: mockSetErrorOverride,
+    } as unknown as CollectElement;
+
+    const mockRef = { current: null as unknown as { setErrorOverride: (message: string) => void } | null };
+
+    const props = {table:'table1', container:{type:Skyflow.ContainerType.COLLECT}}
+
+    renderHook(() => useErrorOverride(mockElement, mockRef, props as any));
+
+    if (mockRef.current) {
+      mockRef.current.setErrorOverride('Test error message');
+    }
+
+    expect(mockSetErrorOverride).toHaveBeenCalledWith('Test error message');
+  });
+
+  it('should not throw an error if element is null', () => {
+    const mockRef = { current: null as unknown as { setErrorOverride: (message: string) => void } | null };
+    const mockProps = {table:'table1', container:{type:Skyflow.ContainerType.COLLECT}}
+
+    renderHook(() => useErrorOverride(null, mockRef, mockProps as any));
+
+    expect(() => {
+      if (mockRef.current) {
+        mockRef.current.setErrorOverride('Test error message');
+      }
+    }).not.toThrow();
+  });
+
+  it('should not set error override if container type is not COLLECT or REVEAL', () => {
+    const mockSetErrorOverride = jest.fn();
+    const mockElement = {
+      setErrorOverride: mockSetErrorOverride,
+    } as unknown as CollectElement;
+
+    const mockRef = { current: null as unknown as { setErrorOverride: (message: string) => void } | null };
+
+    const mockProps = {table:'table1', container: { type: 'INVALID_TYPE' }}
+
+    renderHook(() => useErrorOverride(mockElement, mockRef, mockProps as any));
+
+    if (mockRef.current) {
+      mockRef.current.setErrorOverride('Test error message');
+    }
+
+    expect(mockSetErrorOverride).not.toHaveBeenCalled();
+  });
+
+  it('should set error override for REVEAL container type', () => {
+    const mockSetErrorOverride = jest.fn();
+    const mockElement = {
+      setErrorOverride: mockSetErrorOverride,
+    } as unknown as RevealElement;
+
+    const mockRef = { current: null as unknown as { setErrorOverride: (message: string) => void } | null };
+    const mockProps = {table:'table1', container:{type:Skyflow.ContainerType.REVEAL}}
+
+    renderHook(() => useErrorOverride(mockElement, mockRef, mockProps as any));
+
+    if (mockRef.current) {
+      mockRef.current.setErrorOverride('Test error message');
+    }
+
+    expect(mockSetErrorOverride).toHaveBeenCalledWith('Test error message');
+  });
+});


### PR DESCRIPTION
## Why
The customer is unable to set custom error messages for different skyflow elements: card number, card expiry, cvv, holder name, etc.

## Goal
Should be able to override default error messages for React SDK similar to what we currently support for Skyflow-JS SDK