### PR TITLE
SK-1988: Iframe refactor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "skyflow-react-js",
-  "version": "2.2.0-dev.4d8c08a",
+  "version": "2.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10779,9 +10779,9 @@
       "dev": true
     },
     "skyflow-js": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/skyflow-js/-/skyflow-js-2.1.3.tgz",
-      "integrity": "sha512-pdjOxGWWpI4o/sSE/noEiDmNZ0XAL/VpiXC2yk7Sthy7iSXj8uiiuSpzqBVvJnOYKhg8qDN6cX7LgIQsFeE6KQ==",
+      "version": "2.1.3-beta.1",
+      "resolved": "https://registry.npmjs.org/skyflow-js/-/skyflow-js-2.1.3-beta.1.tgz",
+      "integrity": "sha512-VgzfI4vrOZYD//NziAOhYgYrpOcDv1vuxf2wjPIfH3wigQoAWZ919bIn8M3QtqcnnHkmNDincXbSGZA7HO7Fuw==",
       "requires": {
         "core-js": "^3.6.5",
         "framebus": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "webpack-merge": "^5.8.0"
   },
   "dependencies": {
-    "skyflow-js": "^2.1.3",
+    "skyflow-js": "^2.1.3-beta.1",
     "uuid": "^9.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
**Why**

- Stalled headless iframes consume unnecessary system memory.

**Goal**

- Single client-level headless iframe during Skyflow client instantiation.
- Eliminated redundant headless iframes created by collect, reveal, and composable containers.
