### PR TITLE
SK-2130 fix expiry date validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "skyflow-react-js",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10779,9 +10779,9 @@
       "dev": true
     },
     "skyflow-js": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/skyflow-js/-/skyflow-js-2.3.2.tgz",
-      "integrity": "sha512-huJ4LBd6pXwo70L9Nckv1HzOTBHvFjmuJRyvS2E8WNzePmBr8KZWqzuRMpF469QVdfSUGrRgCu+C4v+GD7vKEQ==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/skyflow-js/-/skyflow-js-2.3.3.tgz",
+      "integrity": "sha512-lmAaOZe2DfpxLlda2ILuBtoOjV67WIjZNARrfEomqSU1BIY7KYXAIZKSHmQ1cP+rnoR0TDSyWCVoblJ+14lztA==",
       "requires": {
         "core-js": "^3.6.5",
         "framebus": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "webpack-merge": "^5.8.0"
   },
   "dependencies": {
-    "skyflow-js": "^2.3.2",
+    "skyflow-js": "^2.3.3",
     "uuid": "^9.0.0"
   },
   "peerDependencies": {

--- a/samples/SkyflowElements/src/index.tsx
+++ b/samples/SkyflowElements/src/index.tsx
@@ -50,3 +50,4 @@ root.render(
     <App />
   </SkyflowElements>
 );
+


### PR DESCRIPTION
## Why
- Expiry date validation is failing for a credit card expiration date with the value of the current month and year (in this case 06/25).

## Goal
- Validation should pass if the current month and year is entered in the expiry date field

## Testing
- Tested locally 
- Unit testing is also done