### PR TITLE
SK-2101/Release/25.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.5.0] - 2025-06-20
+### Added
+- Typescript support for public interfaces in JS SDK.
+
+## [2.4.3] - 2025-06-16
+### Fixed
+- Expiration date validations.
+
+## [2.4.2] - 2025-06-12
+### Fixed
+- Refactor stale elements code.
+
+## [2.4.1] - 2025-06-03
+### Fixed
+- Add check for empty container for collect and reveal.
+### Changed
+- Update 3DS browser details helper function.
+
+## [2.4.0] - 2025-05-26
+### Added
+- Iframe refactoring. 
+
 ## [2.3.3] - 2025-05-08
 ### Added
 - Add overloading method signatures for container initialisation.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "skyflow-react-js",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10779,9 +10779,9 @@
       "dev": true
     },
     "skyflow-js": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/skyflow-js/-/skyflow-js-2.3.3.tgz",
-      "integrity": "sha512-lmAaOZe2DfpxLlda2ILuBtoOjV67WIjZNARrfEomqSU1BIY7KYXAIZKSHmQ1cP+rnoR0TDSyWCVoblJ+14lztA==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/skyflow-js/-/skyflow-js-2.4.1.tgz",
+      "integrity": "sha512-16a22Q8KRojysfG8/hcrbtnG6fYtu4xZXJAepkj4V000cUrZ+D7kvOzR+5kAFi894lqRmtu8KlWjKZ9tYyWr6A==",
       "requires": {
         "core-js": "^3.6.5",
         "framebus": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "webpack-merge": "^5.8.0"
   },
   "dependencies": {
-    "skyflow-js": "^2.3.3",
+    "skyflow-js": "^2.4.1",
     "uuid": "^9.0.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "skyflow-react-js",
   "preferGlobal": true,
   "analyze": false,
-  "version": "2.4.3",
+  "version": "2.4.3-dev.56edcf6",
   "description": "Skyflow React SDK",
   "homepage": "https://github.com/skyflowapi/skyflow-react",
   "main": "lib/index.js",

--- a/samples/SkyflowElements/src/index.tsx
+++ b/samples/SkyflowElements/src/index.tsx
@@ -50,4 +50,3 @@ root.render(
     <App />
   </SkyflowElements>
 );
-

--- a/src/elements/index.ts
+++ b/src/elements/index.ts
@@ -3,7 +3,7 @@
 */
 
 
-import { CardType } from 'skyflow-js/types/core/constants';
+import { CardMetadata } from 'skyflow-js';
 import CollectContainer from 'skyflow-js/types/core/external/collect/collect-container'
 import ComposableContainer from 'skyflow-js/types/core/external/collect/compose-collect-container'
 import RevealContainer from 'skyflow-js/types/core/external/reveal/reveal-container'
@@ -35,7 +35,7 @@ export interface SkyflowCollectElementProps {
 }
 
 export interface SkyflowCollectElementRef {
-    setErrorOverride: (errorMessage: string) => void;
+  setErrorOverride: (errorMessage: string) => void;
 }
 
 export interface SkyflowRevealElementProps {
@@ -76,7 +76,7 @@ export interface ICollectElementOptions {
   enableCopy?: boolean
   allowedFileType?: string[]
   preserveFileName?: boolean
-  cardMetadata ?: ICardMetadata
+  cardMetadata ?: CardMetadata
   masking?: boolean
   maskingChar?: string
   blockEmptyFiles?: boolean
@@ -87,6 +87,6 @@ export type IRevealOptions = {
   format?:string
 }
 
-export type ICardMetadata = {
-  scheme?: typeof CardType[]
-}
+// export type ICardMetadata = {
+//   scheme?: typeof CardType[]
+// }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@
 	Copyright (c) 2022 Skyflow, Inc. 
 */
 import SkyflowElements from './core'
-import Skyflow from 'skyflow-js'
+import Skyflow, { CardType } from 'skyflow-js'
 
 import CardHolderNameElement from './elements/CardHolderName'
 import CardNumberElement from './elements/CardNumber'
@@ -33,8 +33,6 @@ const Env = Skyflow.Env
 const LENGTH_MATCH_RULE = Skyflow.ValidationRuleType.LENGTH_MATCH_RULE
 const REGEX_MATCH_RULE = Skyflow.ValidationRuleType.REGEX_MATCH_RULE
 const ELEMENT_VALUE_MATCH_RULE = Skyflow.ValidationRuleType.ELEMENT_VALUE_MATCH_RULE
-
-const CardType = Skyflow.CardType
 
 export {
   SkyflowElements,


### PR DESCRIPTION
This PR updates the version for `skyflow-js` dependency in React SDK. 