### PR TITLE
SK-2204 Update to latest JS SDK version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.5.1] - 2025-07-24
+### Fixed
+- Element state in event listeners for collect elements in `PROD` env.
+
 ## [2.5.0] - 2025-06-20
 ### Added
 - Typescript support for public interfaces in JS SDK.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "skyflow-react-js",
-  "version": "2.4.3",
+  "version": "2.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4436,9 +4436,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "3.43.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.43.0.tgz",
-      "integrity": "sha512-N6wEbTTZSYOY2rYAn85CuvWWkCK6QweMn7/4Nr3w+gDBeBhk/x4EJeY6FPo4QzDoJZxVTv8U7CMvgWk6pOHHqA=="
+      "version": "3.44.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.44.0.tgz",
+      "integrity": "sha512-aFCtd4l6GvAXwVEh3XbbVqJGHDJt0OZRa+5ePGx3LLwi12WfexqQxcsohb2wgsa/92xtl19Hd66G/L+TaAxDMw=="
     },
     "core-js-compat": {
       "version": "3.39.0",
@@ -10779,9 +10779,9 @@
       "dev": true
     },
     "skyflow-js": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/skyflow-js/-/skyflow-js-2.4.1.tgz",
-      "integrity": "sha512-16a22Q8KRojysfG8/hcrbtnG6fYtu4xZXJAepkj4V000cUrZ+D7kvOzR+5kAFi894lqRmtu8KlWjKZ9tYyWr6A==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/skyflow-js/-/skyflow-js-2.4.2.tgz",
+      "integrity": "sha512-j4n32CB2q9PiPzNPdFnoeGyVYnI+U+IBLd/Fx+QdteeZdDeVkHTZYR4shJmNnwmZiyo7bqb4XucPYXEmwSCuLQ==",
       "requires": {
         "core-js": "^3.6.5",
         "framebus": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "webpack-merge": "^5.8.0"
   },
   "dependencies": {
-    "skyflow-js": "^2.4.1",
+    "skyflow-js": "^2.4.2",
     "uuid": "^9.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
This PR updates the version of `skyflow-js` dependency for React SDK.

## Why
- There was a bug in `skyflow-js` where incorrect values were being sent to element listeners in state in `PROD` environment.

## Goal
- The React SDK should use an updated version of `skyflow-js` where bug is fixed.

## Testing
- Manually tested the changes
