### PR TITLE
SK-2977 add beta build disclaimer banner to README on release

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          token: ${{ secrets.PAT_ACTIONS }}
 
       - uses: actions/setup-node@v1
         with:
@@ -21,6 +22,36 @@ jobs:
 
       - name: install modules
         run: npm install --ignore-scripts
+
+      - name: Resolve Branch for the Tagged Commit
+        id: resolve-branch
+        run: |
+          TAG_COMMIT=$(git rev-list -n 1 ${{ github.ref_name }})
+          BRANCH_NAME=$(git branch -r --contains $TAG_COMMIT | grep -v 'HEAD ->' | grep -o 'origin/.*' | sed 's|origin/||' | head -n 1)
+          if [ -z "$BRANCH_NAME" ]; then
+            echo "Error: Could not resolve branch for the tag."
+            exit 1
+          fi
+          echo "branch_name=$BRANCH_NAME" >> $GITHUB_ENV
+
+      - name: Update beta banner
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          chmod +x ./scripts/toggle_beta_banner.sh
+          ./scripts/toggle_beta_banner.sh README.md "$VERSION"
+
+      - name: Commit changes
+        run: |
+          git config user.name ${{ github.actor }}
+          git config user.email ${{ github.actor }}@users.noreply.github.com
+          git checkout ${{ env.branch_name }}
+          git add README.md
+          if git diff --cached --quiet; then
+            echo "README already up to date - nothing to commit"
+          else
+            git commit -m "[AUTOMATED] Public Beta Release - update beta banner"
+            git push origin ${{ env.branch_name }}
+          fi
 
       - name: Build
         run: npm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,7 @@ jobs:
           git config user.name ${{ github.actor }}
           git config user.email ${{ github.actor }}@users.noreply.github.com
           git add package.json
+          git add README.md
           git commit -m "[AUTOMATED] Public Release - ${{ steps.previoustag.outputs.tag }}"
           git push
 

--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -6,6 +6,7 @@ then
 	echo "Bumping package version to $1"
 
 	sed -E "s/\"version\": .+/\"version\": \"$SEMVER\",/g" package.json > tempfile && cat tempfile > package.json && rm -f tempfile
+	./scripts/toggle_beta_banner.sh README.md "$SEMVER"
 	echo --------------------------
 	echo "Done, Package now at $1"
 

--- a/scripts/toggle_beta_banner.sh
+++ b/scripts/toggle_beta_banner.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Insert or remove the beta-release disclaimer banner in a README, based on
+# whether the given version string is a pre-release build.
+#
+# Usage: scripts/toggle_beta_banner.sh <readme-path> <version>
+#
+# Idempotent: safe to run repeatedly against the same file and version.
+set -euo pipefail
+
+readme_path="$1"
+version="$2"
+
+marker_start="<!-- SKYFLOW-BETA-DISCLAIMER:START -->"
+marker_end="<!-- SKYFLOW-BETA-DISCLAIMER:END -->"
+banner_body="> ⚠️ **Beta release — not for production use.** This is a pre-release build provided for early testing and feedback. It has not completed Skyflow's General Availability (GA) validation, its API may change before the stable release, and it is not covered by production SLAs or support commitments. Do not deploy beta builds to production environments."
+
+is_prerelease() {
+    [[ "$1" =~ -beta\.[0-9]+ ]]
+}
+
+# Strip any existing banner first, so re-running is idempotent regardless of
+# whether one is already present.
+awk -v start="$marker_start" -v end="$marker_end" '
+    { lines[NR] = $0 }
+    END {
+        start_line = 0
+        end_line = 0
+        for (i = 1; i <= NR; i++) {
+            if (lines[i] == start) start_line = i
+            if (lines[i] == end) end_line = i
+        }
+        if (start_line == 0 || end_line == 0) {
+            del_from = -1
+            del_to = -1
+        } else {
+            del_from = start_line
+            del_to = end_line
+            if (del_from > 1 && lines[del_from - 1] == "") del_from--
+            if (del_to < NR && lines[del_to + 1] == "") del_to++
+        }
+        for (i = 1; i <= NR; i++) {
+            if (i >= del_from && i <= del_to) continue
+            print lines[i]
+        }
+    }
+' "$readme_path" > "${readme_path}.tmp"
+mv "${readme_path}.tmp" "$readme_path"
+
+if is_prerelease "$version"; then
+    awk -v start="$marker_start" -v body="$banner_body" -v end="$marker_end" '
+        NR == 1 {
+            print
+            print ""
+            print start
+            print body
+            print end
+            print ""
+            next
+        }
+        { print }
+    ' "$readme_path" > "${readme_path}.tmp"
+    mv "${readme_path}.tmp" "$readme_path"
+fi

--- a/scripts/toggle_beta_banner.test.sh
+++ b/scripts/toggle_beta_banner.test.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TOGGLE="$SCRIPT_DIR/toggle_beta_banner.sh"
+FIXTURE="$(mktemp)"
+MARKER_START="<!-- SKYFLOW-BETA-DISCLAIMER:START -->"
+BANNER_TEXT="Beta release — not for production use"
+
+fail() {
+    echo "FAIL: $1"
+    rm -f "$FIXTURE"
+    exit 1
+}
+
+cat > "$FIXTURE" <<'EOF'
+# skyflow-react-js
+
+A React wrapper for Skyflow JS SDK.
+EOF
+
+# 1. Beta version inserts the banner
+"$TOGGLE" "$FIXTURE" "2.6.0-beta.1"
+[ "$(grep -c -F "$MARKER_START" "$FIXTURE")" -eq 1 ] || fail "banner not inserted for beta version"
+grep -qF "$BANNER_TEXT" "$FIXTURE" || fail "banner text not correct for beta version"
+
+# 2. Re-running with the same beta version stays idempotent (no duplicate)
+"$TOGGLE" "$FIXTURE" "2.6.0-beta.1"
+[ "$(grep -c -F "$MARKER_START" "$FIXTURE")" -eq 1 ] || fail "banner duplicated on repeat run"
+
+# 3. GA version removes the banner
+"$TOGGLE" "$FIXTURE" "2.6.0"
+[ "$(grep -c -F "$MARKER_START" "$FIXTURE")" -eq 0 ] || fail "banner not removed for GA version"
+grep -qF "$BANNER_TEXT" "$FIXTURE" && fail "banner text not removed for GA version"
+
+# 4. Original content survives untouched
+grep -qF "React wrapper" "$FIXTURE" || fail "original README content lost"
+
+rm -f "$FIXTURE"
+echo "PASS: toggle_beta_banner.sh"


### PR DESCRIPTION
## Summary
Adds a standard beta/pre-release disclaimer banner to the README, automatically toggled in and out by the existing release automation — part of the CUST-4287 RCA follow-up ([SK-2977](https://skyflow.atlassian.net/browse/SK-2977)).

- `scripts/toggle_beta_banner.sh` inserts the banner right after the README's title when the version being released is a `-beta.N` pre-release, and removes it on GA releases. Idempotent.
- Wired into `scripts/bump_version.sh` (public/beta path only) and `release.yml`'s existing commit step now stages `README.md`.
- `beta-release.yml` previously had no version-bump or commit step at all (the human hand-edits `package.json` before tagging) — it now also reads that version, updates the banner, and commits+pushes only if the README actually changed.
- `scripts/toggle_beta_banner.test.sh` covers insertion, idempotency, GA removal, and content preservation.

This is one of 8 sibling PRs (android, iOS, js, node, python, react-js, react-native, java) rolling out the same disclaimer text and mechanism across the SDKs. skyflow-go is deferred to a follow-up (no release CI to hook into today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SK-2977]: https://skyflow.atlassian.net/browse/SK-2977?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ