### PR TITLE
SK-3016-gitleaks-detection-multiple-secret-exposures-identified

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,2 @@
+# False positives: sample response tokens (UUID record identifiers) in README.md docs, not real secrets.
+36e823a2532dde303eb21fa0874e334251c0b5c6:README.md:generic-api-key:2711


### PR DESCRIPTION
### Why:
The org-wide Gitleaks scan flagged a generic-api-key finding in README.md (line 2711) — a sample UUID-format token ID in the "Sample Response" documentation block that matches the secret-detection pattern. This is an illustrative example value from API response docs, not a real credential, but the finding needs to be resolved to close out the security review.

### Goal:
Suppress the false-positive finding without altering the visible README content (so SDK consumers still see the real, realistic sample response), by adding a .gitleaksignore file with a fingerprint for the specific finding — Gitleaks' native, built-in suppression mechanism for exactly this case.

Ref: same pattern as [skyflow-react-native#157](https://github.com/skyflowapi/skyflow-react-native/pull/157).

Jira: [SK-3016](https://skyflow.atlassian.net/browse/SK-3016)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SK-3016]: https://skyflow.atlassian.net/browse/SK-3016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ